### PR TITLE
Proposed changes on pr #58

### DIFF
--- a/components/lua_rtos/Lua/modules/mqtt.c
+++ b/components/lua_rtos/Lua/modules/mqtt.c
@@ -245,8 +245,9 @@ static int lmqtt_connected( lua_State* L ) {
     
     rc = MQTTClient_connected(mqtt->client);
 
-		lua_pushinteger( L, rc == MQTTCLIENT_SUCCESS ? 1 : 0 );
-    return 1;
+    lua_pushboolean( L, rc == MQTTCLIENT_SUCCESS ? 1 : 0 );
+
+	return 1;
 }
 
 static int lmqtt_connect( lua_State* L ) {

--- a/components/lua_rtos/Lua/modules/net.c
+++ b/components/lua_rtos/Lua/modules/net.c
@@ -237,7 +237,7 @@ static int lnet_stat(lua_State* L) {
 }
 
 static int lnet_connected(lua_State* L) {
-  lua_pushinteger( L, NETWORK_AVAILABLE() );
+  lua_pushboolean( L, NETWORK_AVAILABLE() );
   return 1;
 }
 

--- a/components/lua_rtos/drivers/gdisplay.c
+++ b/components/lua_rtos/drivers/gdisplay.c
@@ -1,6 +1,6 @@
 #include "sdkconfig.h"
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 #include "esp_attr.h"
 

--- a/components/lua_rtos/drivers/gdisplay.h
+++ b/components/lua_rtos/drivers/gdisplay.h
@@ -1,9 +1,10 @@
 #ifndef DRIVERS_GDISPLAY_H_
 #define DRIVERS_GDISPLAY_H_
 
+#include "sdkconfig.h"
 #include <stdint.h>
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 #define DELAY 0x80
 

--- a/components/lua_rtos/drivers/ili9341.c
+++ b/components/lua_rtos/drivers/ili9341.c
@@ -38,7 +38,7 @@
 
 #include "sdkconfig.h"
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/components/lua_rtos/drivers/ili9341.h
+++ b/components/lua_rtos/drivers/ili9341.h
@@ -39,7 +39,9 @@
 #ifndef ILI9341_H
 #define	ILI9341_H
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#include "sdkconfig.h"
+
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 // Display constants
 #define DELAY 0x80

--- a/components/lua_rtos/drivers/pcd8544.c
+++ b/components/lua_rtos/drivers/pcd8544.c
@@ -29,7 +29,7 @@
 
 #include "sdkconfig.h"
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 #include "freertos/FreeRTOS.h"
 

--- a/components/lua_rtos/drivers/pcd8544.h
+++ b/components/lua_rtos/drivers/pcd8544.h
@@ -30,9 +30,9 @@
 #ifndef PCD8544_H_
 #define PCD8544_H_
 
-#include "luartos.h"
+#include "sdkconfig.h"
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 #include <stdint.h>
 

--- a/components/lua_rtos/drivers/st7735.c
+++ b/components/lua_rtos/drivers/st7735.c
@@ -42,7 +42,7 @@
 
 #include "sdkconfig.h"
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/components/lua_rtos/drivers/st7735.h
+++ b/components/lua_rtos/drivers/st7735.h
@@ -43,7 +43,9 @@
 #ifndef ST7735S_H
 #define	ST7735S_H
 
-#if LUA_RTOS_LUA_USE_GDISPLAY
+#include "sdkconfig.h"
+
+#if CONFIG_LUA_RTOS_LUA_USE_GDISPLAY
 
 #define ST7735_BUFFER 1920
 


### PR DESCRIPTION
* pr don't compile when gdisplay is enabled. LUA_RTOS_LUA_USE_GDISPLAY has been changed by CONFIG_LUA_RTOS_LUA_USE_GDISPLAY.
* net.connected function, return a boolean(false/true) instead an integer (0/1) for coherence with other Lua RTOS parts.
* mqtt.connected function, return a boolean(false/true) instead an integer (0/1) for coherence with other Lua RTOS parts.